### PR TITLE
Handle RAILS_ENV via Rails.env if available

### DIFF
--- a/lib/can_do.rb
+++ b/lib/can_do.rb
@@ -68,6 +68,14 @@ class CanDo
   end
 
   def env
-    ENV["RAILS_ENV"] || ENV["RACK_ENV"]
+    rails_env || rack_env
+  end
+
+  def rails_env
+    defined?(Rails) ? Rails.env : ENV["RAILS_ENV"]
+  end
+
+  def rack_env
+    ENV["RACK_ENV"]
   end
 end


### PR DESCRIPTION
if you work with Rails but RAILS_ENV is not set (e.g. the usual development setup), can_do will mistakenly return nil for the ENV and will not pickup the development: section of your features.env

This is a quick fix to use Rails.env if available (which will default to "development" if RAILS_ENV is not set)
